### PR TITLE
Move global state before BLE callbacks

### DIFF
--- a/main.ino
+++ b/main.ino
@@ -44,6 +44,19 @@ static bool gbConnected = false;
 static bool gbNotifyEnabled = false;
 static uint16_t gbNotifyMax = 20;
 
+// ===== State machine =====
+enum Mode { IDLE, WARMING, SAMPLING, REFRACTORY } mode = IDLE;
+
+float baselinePa = NAN;
+float lpAlpha = 0.0f;           // EMA coefficient
+uint32_t lastSampleMS = 0;
+
+uint16_t trigHoldMS = 0;
+uint32_t modeTS = 0;
+
+int   alcRaw  = 0, alcPeak = 0;
+float lastDeltaHPA = 0.0f;
+
 void gbSendStatus(const String &msg);
 void gbSendLog(const String &msg);
 void gbSendResult(int peakRaw, float peakVoltage);
@@ -167,19 +180,6 @@ void gbSendInitialBurst() {
   gbSendLog(String("ALC ") + alcRaw + " (" + String(v, 2) + " V)");
   gbSendLog(String("PEAK ") + alcPeak);
 }
-
-// ===== State machine =====
-enum Mode { IDLE, WARMING, SAMPLING, REFRACTORY } mode = IDLE;
-
-float baselinePa = NAN;
-float lpAlpha = 0.0f;           // EMA coefficient
-uint32_t lastSampleMS = 0;
-
-uint16_t trigHoldMS = 0;
-uint32_t modeTS = 0;
-
-int   alcRaw  = 0, alcPeak = 0;
-float lastDeltaHPA = 0.0f;
 
 void setup() {
   Serial.begin(115200);


### PR DESCRIPTION
## Summary
- move the state machine and sensor global declarations before the BLE callback classes
- ensure GBServerCallbacks and related code can reference the globals without additional externs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0174af04883288fd4f7bd506d7fb0