### PR TITLE
Reset Gadgetbridge notify chunk size on reconnect

### DIFF
--- a/main.ino
+++ b/main.ino
@@ -72,11 +72,13 @@ class GBServerCallbacks : public NimBLEServerCallbacks {
   void onConnect(NimBLEServer* server) override {
     gbConnected = true;
     gbNotifyEnabled = false;
+    gbNotifyMax = 20;
     gbSendStatus(gbCurrentStatusMessage());
   }
   void onDisconnect(NimBLEServer* server) override {
     gbConnected = false;
     gbNotifyEnabled = false;
+    gbNotifyMax = 20;
     NimBLEDevice::startAdvertising();
   }
   void onMTUChange(uint16_t MTU, ble_gap_conn_desc* desc) override {


### PR DESCRIPTION
## Summary
- reset the Gadgetbridge notification chunk size to the 20 byte default whenever a client connects or disconnects
- keep the existing MTU change handler so later negotiations can still expand the allowed payload size

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e05621f4588328b55cb10f326d8f36