### PR TITLE
Handle invalid BMP280 pressure samples

### DIFF
--- a/main.ino
+++ b/main.ino
@@ -56,6 +56,7 @@ uint32_t modeTS = 0;
 
 int   alcRaw  = 0, alcPeak = 0;
 float lastDeltaHPA = 0.0f;
+bool lastPressureValid = false;
 
 void gbSendStatus(const String &msg);
 void gbSendLog(const String &msg);
@@ -290,12 +291,15 @@ void loop() {
     static uint32_t lastInvalidPressureLog = 0;
 
     float pPa = bmp.readPressure();                 // Pascals
-    if (isnan(pPa)) {
+    bool pressureValid = !isnan(pPa);
+    if (!pressureValid) {
       if (!announcedNoPress || (now - lastInvalidPressureLog >= 1000)) {
         gbSendLog("PRESS --");
         lastInvalidPressureLog = now;
         announcedNoPress = true;
       }
+      lastDeltaHPA = 0.0f;
+      trigHoldMS = 0;
     } else {
       if (isnan(baselinePa)) baselinePa = pPa;        // initialize
 
@@ -310,11 +314,15 @@ void loop() {
       }
       announcedNoPress = false;
     }
+    lastPressureValid = pressureValid;
   } else {
     if (!announcedNoPress) {
       gbSendLog("PRESS --");
       announcedNoPress = true;
     }
+    lastDeltaHPA = 0.0f;
+    trigHoldMS = 0;
+    lastPressureValid = false;
   }
 
   // ----- State machine -----
@@ -322,6 +330,10 @@ void loop() {
     case IDLE: {
       if (!HEATER_ALWAYS_ON) digitalWrite(ALC_SEL_PIN, HIGH); // heater OFF
       if (bmpOK) {
+        if (!lastPressureValid) {
+          trigHoldMS = 0;
+          break;
+        }
         // Require breath threshold for TRIG_SUSTAIN_MS
         if (lastDeltaHPA > TRIG_DELTA_HPA) {
           trigHoldMS += (uint16_t)(1000.0f / SAMPLE_HZ);


### PR DESCRIPTION
## Summary
- reset the stored pressure delta and trigger hold when the BMP280 read fails
- track the validity of the last pressure sample and block idle triggers on invalid data

## Testing
- python3 - <<'PY' ... (simulate NaN pressure handling)

------
https://chatgpt.com/codex/tasks/task_e_68e0561a444c8328a9db1cdffd907b3c